### PR TITLE
Convert from XNAMath to DirectXMath for C++ compilation

### DIFF
--- a/D3DX_DXGIFormatConvert.inl
+++ b/D3DX_DXGIFormatConvert.inl
@@ -226,55 +226,31 @@ typedef uint4 XMUINT4;
 #error C++ compilation required
 #endif
 
-#include <float.h>
-#include <xnamath.h>
+#ifndef D3DX11INLINE
+#define D3DX11INLINE inline
+#endif
+
+#include <algorithm>
+#include <cfloat>
+#include <DirectXMath.h>
 
 #define hlsl_precise
 
-D3DX11INLINE FLOAT D3DX_Saturate_FLOAT(FLOAT _V)
+namespace DirectX
 {
-    return min(max(_V, 0), 1);
+
+D3DX11INLINE float D3DX_Saturate_FLOAT(float _V)
+{
+    return std::min<float>(std::max<float>(_V, 0), 1);
 }
-D3DX11INLINE bool D3DX_IsNan(FLOAT _V)
+D3DX11INLINE bool D3DX_IsNan(float _V)
 {
     return _V != _V;
 }
-D3DX11INLINE FLOAT D3DX_Truncate_FLOAT(FLOAT _V)
+D3DX11INLINE float D3DX_Truncate_FLOAT(float _V)
 {
-    return _V >= 0 ? floor(_V) : ceil(_V);
+    return _V >= 0 ? floorf(_V) : ceilf(_V);
 }
-
-// 2D Vector; 32 bit signed integer components
-typedef struct _XMINT2
-{
-    INT x;
-    INT y;
-} XMINT2;
-
-// 2D Vector; 32 bit unsigned integer components
-typedef struct _XMUINT2
-{
-    UINT x;
-    UINT y;
-} XMUINT2;
-
-// 4D Vector; 32 bit signed integer components
-typedef struct _XMINT4
-{
-    INT x;
-    INT y;
-    INT z;
-    INT w;
-} XMINT4;
-
-// 4D Vector; 32 bit unsigned integer components
-typedef struct _XMUINT4
-{
-    UINT x;
-    UINT y;
-    UINT z;
-    UINT w;
-} XMUINT4;
 
 #endif // HLSL_VERSION > 0
 
@@ -334,7 +310,7 @@ D3DX11INLINE FLOAT D3DX_SRGB_to_FLOAT(UINT val)
 #if HLSL_VERSION > 0
     return asfloat(D3DX_SRGBTable[val]);
 #else
-    return *(FLOAT*)&D3DX_SRGBTable[val];
+    return *reinterpret_cast<const FLOAT*>(&D3DX_SRGBTable[val]);
 #endif
 }
 
@@ -796,5 +772,10 @@ D3DX11INLINE UINT D3DX_INT2_to_R16G16_SINT(XMINT2 unpackedInput)
                      (unpackedInput.y              <<16) );
     return packedOutput;
 }
+
+#if HLSL_VERSION > 0
+#else
+} // namespace DirectX;
+#endif
 
 #endif // __D3DX_DXGI_FORMAT_CONVERT_INL___

--- a/D3DX_DXGIFormatConvert.inl
+++ b/D3DX_DXGIFormatConvert.inl
@@ -230,9 +230,11 @@ typedef uint4 XMUINT4;
 #define D3DX11INLINE inline
 #endif
 
+#include <DirectXMath.h>
+
 #include <algorithm>
 #include <cfloat>
-#include <DirectXMath.h>
+#include <cmath>
 
 #define hlsl_precise
 
@@ -245,7 +247,7 @@ D3DX11INLINE float D3DX_Saturate_FLOAT(float _V)
 }
 D3DX11INLINE bool D3DX_IsNan(float _V)
 {
-    return _V != _V;
+    return isnan(_V);
 }
 D3DX11INLINE float D3DX_Truncate_FLOAT(float _V)
 {

--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 ## Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party's policies.
+
+# Version History
+
+April 2021 - Updated to use DirectXMath in the Windows SDK instead of legacy XNAMath from the DirectX SDK for C++ support
+
+June 2010 - Release in legacy DirectX SDK


### PR DESCRIPTION
The ``D3DX_DXGIFormatConvert.inl`` shipped in the legacy DirectX SDK relied on XNAMath.h which shipped in the same SDK for C++ support.

The modern Windows SDK contains DirectXMath instead per [this blog post](https://walbourn.github.io/introducing-directxmath/)

The primary change here is to wrap all the C++ functions in the ``DirectX`` namespace so all symbols resolve without using statements or fully-qualified names which wouldn't compile for HLSL.